### PR TITLE
Clarify release process requires creating GitHub release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,11 @@ Run the following:
 * `npm version minor`
 * `git push --follow-tags`
 
-Then a [GitHub Action](https://github.com/steren/rtx-on/blob/main/.github/workflows/npm-publish.yml) automatically publishes to npm.
+Then create a GitHub release for the tag you just pushed, either from the
+[releases page](https://github.com/steren/rtx-on/releases/new) or with:
+
+* `gh release create "v$(node -p "require('./package.json').version")" --generate-notes`
+
+Creating the release is what triggers the
+[GitHub Action](https://github.com/steren/rtx-on/blob/main/.github/workflows/npm-publish.yml)
+that publishes to npm. Pushing the tag on its own does not publish anything.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rtx-on",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rtx-on",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "webgl-path-tracing": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtx-on",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Use proper ray traced shadow instead of the boring box-shadow",
   "directories": {
     "example": "examples"


### PR DESCRIPTION
## Summary
Updated the contribution guidelines to clarify that creating a GitHub release is a required step in the publishing process, not optional. The previous documentation was misleading as it suggested the GitHub Action automatically publishes after pushing tags, when in fact the release creation is what triggers the publication.

## Changes
- **CONTRIBUTING.md**: Updated release instructions to explicitly require creating a GitHub release after pushing the version tag, with two methods provided (web UI or `gh` CLI)
- **package.json**: Bumped version from 0.18.0 to 0.19.0

## Details
The key clarification is that pushing the tag alone does not trigger npm publication. The GitHub Action only publishes when a release is created for that tag. This prevents accidental or incomplete releases and makes the process more explicit for contributors.

https://claude.ai/code/session_01LAMZw1pU1rUfxHoWfoxUbU