### PR TITLE
Switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,22 +1,28 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+# Publishes the package to npm when a GitHub release is published.
+# Authentication uses npm trusted publishing (OIDC), so no npm token is stored
+# in this repository. The trust relationship is configured once on npmjs.com:
+# Package settings -> Trusted publisher -> GitHub Actions (workflow: npm-publish.yml)
+# See https://docs.npmjs.com/trusted-publishers
 
 name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+      # Trusted publishing requires npm 11.5.1 or later
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,20 @@ Then create a GitHub release for the tag you just pushed, either from the
 Creating the release is what triggers the
 [GitHub Action](https://github.com/steren/rtx-on/blob/main/.github/workflows/npm-publish.yml)
 that publishes to npm. Pushing the tag on its own does not publish anything.
+
+### Authentication
+
+The workflow authenticates to npm with
+[trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), so there
+is no npm token stored in this repository and nothing to rotate. The trust
+relationship is configured once on npmjs.com, under the package's
+*Settings -> Trusted publisher*:
+
+* Publisher: GitHub Actions
+* Organization or user: `steren`
+* Repository: `rtx-on`
+* Workflow filename: `npm-publish.yml`
+* Environment: (leave empty)
+
+As a side effect, published versions also carry
+[provenance attestations](https://docs.npmjs.com/generating-provenance-statements).


### PR DESCRIPTION
## Summary
Migrated the npm publishing workflow from token-based authentication to OIDC trusted publishing, eliminating the need to store and rotate npm tokens in the repository.

## Key Changes
- **Authentication method**: Replaced `NODE_AUTH_TOKEN` secret with OIDC-based trusted publishing
- **Workflow trigger**: Changed release trigger from `created` to `published` to align with best practices
- **Action versions**: Updated `actions/checkout` and `actions/setup-node` to v4, and Node.js version to 24
- **npm version**: Added explicit upgrade to latest npm (11.5.1+) to support trusted publishing
- **Permissions**: Added explicit OIDC token permissions (`id-token: write`) required for trusted publishing
- **Documentation**: Updated CONTRIBUTING.md with detailed instructions on configuring the trust relationship on npmjs.com and noted the automatic provenance attestations

## Implementation Details
The trust relationship is configured once on npmjs.com under the package's Settings → Trusted publisher section, with the following configuration:
- Publisher: GitHub Actions
- Organization/user: `steren`
- Repository: `rtx-on`
- Workflow filename: `npm-publish.yml`

This approach provides better security posture by eliminating long-lived credentials and automatically generates provenance attestations for published versions.

https://claude.ai/code/session_0197MyhJhnSAK1jmnLS8e1F1